### PR TITLE
Prevent the same filename for inputModel and output model

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ In order to train a text classifier using the method described in [2](#bag-of-tr
 ```
 $ ./fasttext supervised -input train.txt -output model
 
-$ ./fasttext supervised -input train.txt -output model -inputModel model.bin -incr   # for incremental training
+$ ./fasttext supervised -input train.txt -output newermodel -inputModel model.bin -incr   # for incremental training
 ```
 
 where `train.txt` is a text file containing a training sentence per line along with the labels.

--- a/src/main.cc
+++ b/src/main.cc
@@ -292,12 +292,17 @@ void analogies(const std::vector<std::string> args) {
 void train(const std::vector<std::string> args) {
   Args a = Args();
   a.parseArgs(args);
-  FastText fasttext;
-  std::ofstream ofs(a.output+".bin");
+
+  if (a.output + ".bin" == a.inputModel) {
+    throw std::invalid_argument("\n" + a.inputModel + ": Using the same filename for inputModel and output model would overwrite the inputModel and fail the incremental training");
+  }
+  std::ofstream ofs(a.output + ".bin");
   if (!ofs.is_open()) {
     throw std::invalid_argument(a.output + ".bin cannot be opened for saving.");
   }
   ofs.close();
+  
+  FastText fasttext;
   fasttext.train(a);
   fasttext.saveModel();
   fasttext.saveVectors();


### PR DESCRIPTION
Sorry, I created this PR without filing an issue first, because I had no way to raise an issue.

Using the same filename for inputModel and output model would empty/overwrite the inputModel and also fail the incremental training. Maybe there is a better way to prevent this or there is a better warning for this.